### PR TITLE
split meta emission function

### DIFF
--- a/Editor/Calculate Meta Emission.tsrt
+++ b/Editor/Calculate Meta Emission.tsrt
@@ -1,0 +1,4 @@
+void CalculateMetaEmission()
+{
+    Emission = (UNITY_SAMPLE_TEX2D_SAMPLER(_EmissionMap, _MainTex, TSR_TRANSFORM_TEX(Uvs, _EmissionMap)) * _EmissionColor).rgb;
+}

--- a/Editor/Calculate Meta Emission.tsrt.meta
+++ b/Editor/Calculate Meta Emission.tsrt.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 40c191ac5f3f6884ebab282905401b19
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e966c729b2da454eb0913de373669af, type: 3}

--- a/Editor/Emission.asset
+++ b/Editor/Emission.asset
@@ -86,10 +86,10 @@ MonoBehaviour:
       CustomType: 
     VariableKeywords: []
     CodeKeywords: []
-  - Name: CalculateEmission
+  - Name: CalculateMetaEmission
     AppendAfter: '#K#META_FRAGMENT_FUNCTION'
     Queue: 90
-    ShaderFunctionCode: {fileID: -544282384758852595, guid: a27b6877131e80442b4a6783c1de978c,
+    ShaderFunctionCode: {fileID: -544282384758852595, guid: 40c191ac5f3f6884ebab282905401b19,
       type: 3}
     UsedVariables:
     - Name: _EmissionMap


### PR DESCRIPTION
 To avoid accidental targeting of the meta pass the emission set call for the meta pass has been isolated in it's own function.

An example of this behaviour happening was in combination with the AudioLink module